### PR TITLE
Support ppc64le: PowerPC 64-bit in little-endian mode. Fix #41

### DIFF
--- a/builder/sh_src/build_car.sh
+++ b/builder/sh_src/build_car.sh
@@ -443,6 +443,7 @@ car_config() { # (configure options)
                 Sparc64) opt__ARCH=Sparc ;;
                 x86_64)  opt__ARCH=i686 ;;
                 ppc64)   opt__ARCH=ppc ;;
+                ppc64le) opt__ARCH=ppc ;; # 32-bit PowerPC is only big-endian
                 *) true ;; # assume 32-bit
             esac
         fi
@@ -452,6 +453,7 @@ car_config() { # (configure options)
                 Sparc64) true ;;
                 x86_64)  true ;;
                 ppc64)   true ;;
+                ppc64le) true ;;
                 aarch64) true ;;
                 *) opt__ARCH=empty ;; # force error # TODO: emit error instead?
                 # *) echo "{configuration error: This executable requires a 64 bit architecture}" 1>&2 && exit 1 ;;

--- a/builder/sh_src/config-sysdep/ciao_sysconf
+++ b/builder/sh_src/config-sysdep/ciao_sysconf
@@ -33,7 +33,8 @@ case "$arch" in
     sparc)     arch=Sparc ;;
     sparc64)   arch=Sparc64 ;;
     ppc)       arch=ppc ;;
-    ppc64)     arch=ppc64 ;;
+    ppc64)     arch=ppc64   ;; # Big-endian mode
+    ppc64le)   arch=ppc64le ;; # Little-endian mode
     powerpc)   arch=ppc ;;
     "Power Macintosh") arch=ppc ;;
     i[3456]86) arch=i686 ;;

--- a/builder/sh_src/config-sysdep/config-sysdep.sh
+++ b/builder/sh_src/config-sysdep/config-sysdep.sh
@@ -376,6 +376,7 @@ emit_cdefs() {
         *x86_64)         emit_cdef "USE_OWN_MALLOC" ;;
         *x86_JS)         true ;;
         *ppc64)          emit_cdef "USE_OWN_MALLOC" ;;
+        *ppc64le)        emit_cdef "USE_OWN_MALLOC" ;;
         *aarch64)        emit_cdef "USE_OWN_MALLOC" ;;
         # (assume 32-bit)
         *) emit_cdef "USE_MMAP"; emit_cdef "ANONYMOUS_MMAP" ;;

--- a/builder/src/car_maker.pl
+++ b/builder/src/car_maker.pl
@@ -375,11 +375,13 @@ sysconf_arch(M32, M64, Arch) :-
 arch32('Sparc64', 'Sparc') :- !.
 arch32('x86_64', 'i686') :- !.
 arch32('ppc64', 'ppc') :- !.
+arch32('ppc64le', 'ppc') :- !.
 arch32(Arch, Arch). % assume 32-bit
 
 arch64('Sparc64', 'Sparc64') :- !.
 arch64('x86_64', 'x86_64') :- !.
 arch64('ppc64', 'ppc64') :- !.
+arch64('ppc64le', 'ppc64le') :- !.
 arch64(_, empty). % force error % TODO: emit error instead?
 
 ciao_sysconf_sh := ~bundle_path(builder, 'sh_src/config-sysdep/ciao_sysconf').

--- a/core/engine/eng_predef.h
+++ b/core/engine/eng_predef.h
@@ -43,7 +43,7 @@ typedef double flt64_t;
 
 /* ------------------------------------------------------------------------- */
 
-#if defined(x86_64) || defined(Sparc64) || defined(ppc64) || defined(aarch64) /* 64-bit */
+#if defined(x86_64) || defined(Sparc64) || defined(ppc64) || defined(ppc64le) || defined(aarch64) /* 64-bit */
 /* Definitions for 64-bit tag scheme */
 typedef int64_t intmach_t;
 typedef uint64_t uintmach_t;

--- a/core/library/hrtime/hrtime.h
+++ b/core/library/hrtime/hrtime.h
@@ -99,9 +99,9 @@ __inline__ uint64 hrtime(void) {
 
 #define hrtime()                                        \
   ({                                                    \
-    register uint64 x;                                  \
+    register uint64 t;                                  \
     __asm__ __volatile__ ("mftb %0"  : "=r"(t));        \
-    x;                                                  \
+    t;                                                  \
   })
 
 #define hrfreq() ((uint64)1<<20)

--- a/core/library/tabling/engine.h
+++ b/core/library/tabling/engine.h
@@ -12,7 +12,7 @@
 /* -------------- */
 /* WARNING: these macros need Ciao tag scheme */
 
-#if defined(x86_64) || defined(Sparc64) || defined(ppc64) /* 64-bit */
+#if defined(x86_64) || defined(Sparc64) || defined(ppc64) || defined(ppc64le) /* 64-bit */
 #define PairInitTag  0xC000000000000001  //to mark the begining of a list in trie.c
 #define PairEndTag   0xD000000000000001  //to mark the end of a list in trie.c
 
@@ -107,7 +107,7 @@
 #define IsNonVarTerm(TERM) (!IsVar(TERM))
 #define IsFreeVar(X) (IsVar(X) && ((X) == *TaggedToPointer(X)))
 
-#if defined(x86_64) || defined(Sparc64) || defined(ppc64) /* 64-bit */
+#if defined(x86_64) || defined(Sparc64) || defined(ppc64) || defined(ppc64le) /* 64-bit */
 #define IsTrieVar(TERM)   (((TERM) & 0xF000000000000003) == VarTrie)
 #define IsTrieAttr(TERM)  (((TERM) & 0xF000000000000003) == AttrTrie)
 #else /* 32-bit */


### PR DESCRIPTION
The test suite passes as much as it does on the `x64` architecture on Linux: see #42